### PR TITLE
Add select with Arel

### DIFF
--- a/lib/rails_select_on_includes/version.rb
+++ b/lib/rails_select_on_includes/version.rb
@@ -1,3 +1,3 @@
 module RailsSelectOnIncludes
-  VERSION = "0.4.9"
+  VERSION = "0.4.10"
 end


### PR DESCRIPTION
Add:
Select with aliased arel function: .select(Comment.arel_table[:id].count.as('comments_count'))
Select with aliased arel attirubte: .select(Comment.arel_table[:column].as('column_alias'))

Fix:
Select with double spaces around AS