### PR TITLE
Improves TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
+---
 sudo: false
+cache: bundler
 language: ruby
+
 rvm:
-  - 2.4.4
-  - 2.5.3
-  - 2.3.7
+  - 2.4
+  - 2.5
+  - 2.6
+  - ruby-head
+  - truffleruby
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+    - rvm: truffleruby
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: bundler
 language: ruby
 
 rvm:
-  - 2.4
   - 2.5
   - 2.6
   - ruby-head

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/alekseyl/rails_select_on_includes.svg?branch=master)](https://travis-ci.org/alekseyl/rails_select_on_includes)
+
 # New Features
 Selected virtual attributes will be now typecasted as usual attributes
 

--- a/rails_select_on_includes.gemspec
+++ b/rails_select_on_includes.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">=6"
 
   spec.add_development_dependency "rails", ">=6"
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 1.13"
+  spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency 'sqlite3'
 
   spec.add_development_dependency 'byebug'

--- a/rails_select_on_includes.gemspec
+++ b/rails_select_on_includes.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 6"
 
   spec.add_development_dependency "rails", ">= 6"
-  spec.add_development_dependency "bundler", ">= 2"
+  spec.add_development_dependency "bundler", ">= 1.13"
   spec.add_development_dependency "rake", ">= 13.0"
   spec.add_development_dependency 'sqlite3'
 

--- a/rails_select_on_includes.gemspec
+++ b/rails_select_on_includes.gemspec
@@ -30,11 +30,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">=6"
+  spec.add_dependency "activerecord", ">= 6"
 
-  spec.add_development_dependency "rails", ">=6"
-  spec.add_development_dependency "bundler", ">= 1.13"
-  spec.add_development_dependency "rake", ">= 10.0"
+  spec.add_development_dependency "rails", ">= 6"
+  spec.add_development_dependency "bundler", ">= 2"
+  spec.add_development_dependency "rake", ">= 13.0"
   spec.add_development_dependency 'sqlite3'
 
   spec.add_development_dependency 'byebug'


### PR DESCRIPTION
* Relaxes development dependencies for bundler and rake
* Removes testing against Ruby 2.3 (EOL reached)
* Adds testing against Ruby 2.6, Ruby head and TruffleRuby
* Adds build status icon to the README